### PR TITLE
Replace gulp-util.  Upgrade dependencies.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var gutil       = require('gulp-util');
+var PluginError = require('plugin-error');
 var through     = require('through2');
 var transformer = require('lebab');
 
@@ -12,7 +12,7 @@ module.exports = function (options) {
             return callback(null, file);
 
         if (file.isStream())
-            return callback(new gutil.PluginError('gulp-lebab', 'Streaming not supported'));
+            return callback(new PluginError('gulp-lebab', 'Streaming not supported'));
 
         try {
             var output = transformer.transform(file.contents.toString(), [
@@ -38,7 +38,7 @@ module.exports = function (options) {
             this.push(file);
         } 
         catch (err) {
-            this.emit('error', new gutil.PluginError('gulp-lebab', err, {fileName: file.path, showProperties: true, showStack: true}));
+            this.emit('error', new PluginError('gulp-lebab', err, {fileName: file.path, showProperties: true, showStack: true}));
         }
 
         callback();

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "gulp-lebab",
   "description": "",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Selçuk Fatih Sevinç",
   "license": "MIT",
   "engines": {
     "node": ">=0.10.x"
   },
   "dependencies": {
-    "gulp-util": "3.0.7",
-    "through2": "2.0.1",
-    "lebab": "^2.7.7"
+    "plugin-error": "1.0.1",
+    "through2": "3.0.1",
+    "lebab": "^3.1.0"
   },
   "devDependencies": {},
   "main": "index.js",


### PR DESCRIPTION
Replaces gulp-util per https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 (replaces gutil.PluginError with plugin-error).
Upgrades lebab to v3.1.0 and through2 to v3.0.1.